### PR TITLE
Replace permission to read GeoIP license key

### DIFF
--- a/terraform/iam_user.tf
+++ b/terraform/iam_user.tf
@@ -10,6 +10,6 @@ module "iam_user" {
   }
 
   entity         = "ansible-role-cyhy-commander"
-  ssm_parameters = ["/github/oauth_token"]
+  ssm_parameters = ["/github/oauth_token", "/cyhy/core/geoip/license_key"]
   tags           = var.tags
 }


### PR DESCRIPTION
## 🗣 Description

This pull request replaces permission to read the GeoIP license key from AWS SSM Parameter Store.

## 💭 Motivation and Context

This permission, once thought unnecessary, is indeed necessary.  I had snookered myself into thinking that it wasn't by forgetting to `terraform apply` the test user after removing the permission.

## 🧪 Testing

All molecule tests and pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
