### PR TITLE
Update the supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,9 +15,15 @@ galaxy_info:
   min_ansible_version: 2.10
   namespace: cisagov
   platforms:
+    # cyhy-commander is still Python 2 and with distributions ending support for
+    # Python 2 we can only support a limited number of platforms.
     - name: Debian
       versions:
         - stretch
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
   role_name: cyhy_commander
 
 dependencies:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,16 +16,15 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  # cyhy-commander is Python 2 only, and the only platform we currently support
-  # for Python 2 is Debian Stretch. Until this restriction changes we need to
-  # disable testing for all other platforms.
+  # cyhy-commander is still Python 2 and with distributions ending support for
+  # Python 2 we can only support a limited number of platforms.
   # - name: amazonlinux2
   #   image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
-  # - name: debian10
-  #   image: debian:buster-slim
+  - name: debian10
+    image: debian:buster-slim
   # - name: debian11
   #   image: debian:bullseye-slim
   # - name: debian12
@@ -36,8 +35,8 @@ platforms:
   #   image: fedora:34
   # - name: fedora35
   #   image: fedora:35
-  # - name: ubuntu18
-  #   image: ubuntu:bionic
+  - name: ubuntu18
+    image: ubuntu:bionic
   # - name: ubuntu20
   #   image: ubuntu:focal
 provisioner:

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,12 @@
 ---
 - hosts: all
-  name: Install pip3/python3 and remove pip2/python2
+  name: Install pip3/python3 and pip2/python2
   become: yes
   become_method: sudo
   roles:
-    - pip
-    - python
-    - remove_python2
+    - role: pip
+      vars:
+        install_pip2: true
+    - role: python
+      vars:
+        install_python2: true

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,12 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
+  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
+  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,7 +5,5 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,12 +1,9 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
-  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
-  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,8 +12,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
+@pytest.mark.parametrize("pkg", ["curl", "git", "unzip"])
+def test_apt_packages(host, pkg):
+    """Test that the apt packages were installed."""
+    assert host.package(pkg).is_installed
+
+
 @pytest.mark.parametrize("pkg", ["cyhy-commander"])
-def test_packages(host, pkg):
+def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
     assert pkg in host.pip_package.get_packages()
 
@@ -21,7 +27,6 @@ def test_packages(host, pkg):
 @pytest.mark.parametrize(
     "f",
     [
-        "/var/local/cyhy/commander",
         "/var/log/cyhy",
         "/var/cyhy/commander",
         "/lib/systemd/system/cyhy-commander.service",

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,7 +21,7 @@ def test_apt_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["cyhy-commander"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip_package.get_packages()
+    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,7 +18,7 @@ def test_apt_packages(host, pkg):
     assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("pkg", ["cyhy-commander"])
+@pytest.mark.parametrize("pkg", ["cyhy-commander", "docutils"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
     assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,38 +3,15 @@
 
 #
 # Install curl and unzip; they are needed by cyhy_core/var/load_places.sh
+# Install git so that pip can install from a git URL
 #
 - name: Install curl and unzip
   ansible.builtin.package:
     name:
       - curl
+      - git
       - unzip
 
-#
-# Grab the cyhy-commander code
-#
-- name: Create the /var/local/cyhy/commander directory
-  ansible.builtin.file:
-    mode: 0755
-    path: /var/local/cyhy/commander
-    state: directory
-- name: Download the cyhy-commander tarball
-  ansible.builtin.get_url:
-    url: https://api.github.com/repos/cisagov/cyhy-commander/tarball/develop
-    dest: /tmp/cyhy-commander.tgz
-    headers:
-      Authorization: token {{ github_oauth_token }}
-- name: Unarchive the cyhy-commander tarball
-  ansible.builtin.unarchive:
-    src: /tmp/cyhy-commander.tgz
-    dest: /var/local/cyhy/commander
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-#
-# Now we need to install the cyhy-commander dependencies
-#
 # TODO: Figure out why we can't just put docutils in cyhy-commander/setup.py
 - name: Install docutils, since cyhy-commander needs it
   ansible.builtin.pip:
@@ -43,7 +20,11 @@
 
 - name: Install cyhy-commander
   ansible.builtin.pip:
-    name: file:///var/local/cyhy/commander
+    executable: /usr/bin/pip2
+    name: "git+https://git:{{ github_oauth_token }}@github.com/cisagov/cyhy-commander.git"
+  # The value of github_oauth_token is sensitive so we need to ensure that it
+  # is not accidentally leaked if the task fails.
+  no_log: true
 
 # Create some directories
 - name: Create some directories that cyhy-commander requires

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,15 +13,12 @@
       - unzip
 
 # TODO: Figure out why we can't just put docutils in cyhy-commander/setup.py
-- name: Install docutils, since cyhy-commander needs it
-  ansible.builtin.pip:
-    name:
-      - docutils
-
-- name: Install cyhy-commander
+- name: Install cyhy-commander and docutils (a cyhy-commander dependency)
   ansible.builtin.pip:
     executable: /usr/bin/pip2
-    name: "git+https://git:{{ github_oauth_token }}@github.com/cisagov/cyhy-commander.git"
+    name:
+      - git+https://git:{{ github_oauth_token }}@github.com/cisagov/cyhy-commander.git
+      - docutils
   # The value of github_oauth_token is sensitive so we need to ensure that it
   # is not accidentally leaked if the task fails.
   no_log: true


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the platforms supported by this Ansible role in addition to ensuring that the [cyhy-commander] package is installed with `pip2`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## ⚠ Note ##

This pull request is reliant on the merge of the following:

- cisagov/ansible-role-pip#50
- cisagov/ansible-role-python#46
- cisagov/ansible-role-cyhy-core#65

## 💭 Motivation and context ##

We are in the process of updating the instances in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis) to use Debian Buster for instances running Python 2 code. With the above mentioned PRs for Python/pip installation we can expand the supported platforms. Additionally we update the installation process so that the [cyhy-commander] package is installed directly with pip.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Revert dependencies to default branches.

[cyhy-commander]: https://github.com/cisagov/cyhy-commander
