### PR TITLE
Add ability to set ownership of created files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,10 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| file_owner_group | The name of the group that should own any non-system files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| file_owner_username | The name of the user that should own any non-system files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 
 ## Dependencies ##
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["curl", "git", "unzip"])
+@pytest.mark.parametrize("pkg", ["curl", "unzip"])
 def test_apt_packages(host, pkg):
     """Test that the apt packages were installed."""
     assert host.package(pkg).is_installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,8 +29,8 @@
     path: "{{ item }}"
     state: directory
   loop:
-    - /var/log/cyhy
     - /var/cyhy/commander
+    - /var/log/cyhy
 
 # Copy the systemd unit file
 - name: Copy the systemd unit file for cyhy-commander

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,9 @@
 # Copy the systemd unit file
 - name: Copy the systemd unit file for cyhy-commander
   ansible.builtin.copy:
-    src: cyhy-commander.service
     dest: /lib/systemd/system/cyhy-commander.service
     mode: 0644
+    src: cyhy-commander.service
 
 # Don't enable cyhy-commander here; we do that when we spin up an instance
 # so remaining setup tasks can be completed first

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,9 @@
 # Create some directories
 - name: Create some directories that cyhy-commander requires
   ansible.builtin.file:
+    group: "{{ file_owner_group | default(omit) }}"
     mode: 0755
+    owner: "{{ file_owner_username | default(omit) }}"
     path: "{{ item }}"
     state: directory
   loop:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,11 @@
 
 #
 # Install curl and unzip; they are needed by cyhy_core/var/load_places.sh
-# Install git so that pip can install from a git URL
 #
 - name: Install curl and unzip
   ansible.builtin.package:
     name:
       - curl
-      - git
       - unzip
 
 # TODO: Figure out why we can't just put docutils in cyhy-commander/setup.py


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The primary goal of this pull request is to add two optional variables that can be used to set ownership of any non-system files or directories created by this role. However it also does a bit of alphabetical sorting (to align with our best practices) and removes a dependency that is no longer used.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Outside of being generally useful this will allow us to set the owner of these files to the `cyhy` user when used in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis). This is a viable option now that the `cyhy` user is created before this role is called as part of the image building playbook. The rest is just cleanup while we're here.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
